### PR TITLE
added cache to config parameters

### DIFF
--- a/README
+++ b/README
@@ -16,6 +16,7 @@ Edit your index.php:
 $app['autoloader']->registerNamespace('Nutwerk', __DIR__.'/vendor/nutwerk-orm-extension/lib');
 $app->register(new Nutwerk\Extension\DoctrineORMExtension(), array(
     'db.orm.class_path'            => __DIR__.'/vendor/doctrine2-orm/lib',
+    'db.orm.cache'                 => new Doctrine\Common\Cache\ApcCache(),
     'db.orm.proxies_dir'           => __DIR__.'/var/cache/doctrine/Proxy',
     'db.orm.proxies_namespace'     => 'DoctrineProxy',
     'db.orm.auto_generate_proxies' => true,

--- a/lib/Nutwerk/Extension/DoctrineORMExtension.php
+++ b/lib/Nutwerk/Extension/DoctrineORMExtension.php
@@ -70,8 +70,8 @@ class DoctrineORMExtension implements ServiceProviderInterface
 
             $config = new ORMConfiguration;
             $cache = new ArrayCache;
-            $config->setMetadataCacheImpl($cache);
-            $config->setQueryCacheImpl($cache);
+            $config->setMetadataCacheImpl($app['db.orm.cache']);
+            $config->setQueryCacheImpl($app['db.orm.cache']);
 
             $chain = new DriverChain;
             foreach((array)$app['db.orm.entities'] as $entity) {


### PR DESCRIPTION
Hi,
I added config param for Doctrine2 cache as it's described [here](http://www.doctrine-project.org/docs/orm/2.1/en/reference/configuration.html#metadata-cache-recommended). Maybe modify a little README because I think it's not obvious that for development you should use just `ArrayCache` and for production `ApcCache`, etc.

Maybe like this:

```
//'db.orm.cache'    => new Doctrine\Common\Cache\ApcCache(), // production
'db.orm.cache'    => new Doctrine\Common\Cache\ArrayCache(), // development
```

What do you think?
