### PR TITLE
Make db.orm.class_path optional

### DIFF
--- a/README
+++ b/README
@@ -26,6 +26,7 @@ $app->register(new Nutwerk\Provider\DoctrineORMServiceProvider(), array(
     )),
 ));
 
+Note: the db.orm.class_path parameter is optional (useful if you'd like to use another class loading mechanism than the one provided by Silex).
 
 By default this setup assumes you put your entities beneath app/Entity/*
 

--- a/lib/Nutwerk/Provider/DoctrineORMServiceProvider.php
+++ b/lib/Nutwerk/Provider/DoctrineORMServiceProvider.php
@@ -32,7 +32,9 @@ class DoctrineORMServiceProvider implements ServiceProviderInterface
         $this->setOrmDefaults($app);
         $this->loadDoctrineOrm($app);
 
-        $app['autoloader']->registerNamespace('Doctrine\\ORM', $app['db.orm.class_path']);
+        if(isset($app['db.orm.class_path'])) {
+            $app['autoloader']->registerNamespace('Doctrine\\ORM', $app['db.orm.class_path']);
+        }
     }
 
     private function loadDoctrineOrm(Application $app)


### PR DESCRIPTION
This PR makes the db.orm.class_path an optional parameter, as suggested in the [example in the Silex documentation](http://silex.sensiolabs.org/doc/providers.html#class-loading).
This will allow users to use other autoloading mechanisms than the one supplied by Silex.
