### PR TITLE
Added additional cache settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,24 @@ Below you'll find all the parameters with their defaults (they can also be found
 
     _Default:_ ``new ArrayCache``
 
-    Defines what caching method should be used. The default (ArrayCache) should be fine when you're developing, but in a production environment you probably want to change this to something like APC or Memcache.
+    Defines what caching method should be used for both the Metadata cache and the Query cache. The default (ArrayCache) should be fine when you're developing, but in a production environment you probably want to change this to something like APC or Memcache.
     More information can be found in [Chapter 22. Caching](http://docs.doctrine-project.org/projects/doctrine-orm/en/2.1/reference/caching.html "Doctrine 2 ORM 2.1 Documentation") of the Doctrine 2 ORM 2.1 documentation.
+
+*   __db.orm.cache_metadata__
+
+    _Default:_ db.orm.cache
+
+    If you wish to use a different caching method for your Metadata cache than the one defined in db.orm.cache, you can set it using this parameter.
+
+*   __db.orm.cache_query__
+
+    _Default:_ db.orm.cache
+
+    If you wish to use a different caching method for your Query cache than the one defined in db.orm.cache, you can set it using this parameter.
+
+*   __db.orm.cache_result__
+
+    Set this parameter if you wish to configure result caching.
 
 *   __db.orm.class_path__
 

--- a/lib/Nutwerk/Provider/DoctrineORMServiceProvider.php
+++ b/lib/Nutwerk/Provider/DoctrineORMServiceProvider.php
@@ -71,11 +71,22 @@ class DoctrineORMServiceProvider implements ServiceProviderInterface
     {
         $app['db.orm.config'] = $app->share(function() use($app) {
 
-            $cache = $app['db.orm.cache'];
             $config = new ORMConfiguration;
-            $config->setMetadataCacheImpl($cache);
-            $config->setQueryCacheImpl($cache);
 
+            // Metadata Cache (defaults to db.orm.cache)
+            $metadataCache = (isset($app['db.orm.cache_metadata'])) ? $app['db.orm.cache_metadata'] : $app['db.orm.cache'];
+            $config->setMetadataCacheImpl($metadataCache);
+
+            // Query Cache (defaults to db.orm.cache)
+            $queryCache = (isset($app['db.orm.cache_query'])) ? $app['db.orm.cache_query'] : $app['db.orm.cache'];
+            $config->setQueryCacheImpl($queryCache);
+            
+            // Result Cache (not configured by default)
+            if(isset($app['db.orm.cache_result'])) {
+                $config->setResultCacheImpl($app['db.orm.cache_result']);
+            }
+
+            // Entities / Drivers
             $chain = new DriverChain;
             foreach((array)$app['db.orm.entities'] as $entity) {
                 switch($entity['type']) {


### PR DESCRIPTION
This PR allows you to set a different cache driver for the metadata and query cache (which used to be both defined by 1 parameter, `db.orm.cache`).
It should be backwards compatible, because when there are no specific drivers set for either the metadata cache and/or the query cache, it defaults to the value of `db.orm.cache` which still defaults to an instance of `ArrayCache`.

Besides that this PR also allows you to set a default result cache driver, which wasn't possible at all in early versions.
