### PR TITLE
added boot method to the DoctrineORMServiceProvider

### DIFF
--- a/lib/Nutwerk/Provider/DoctrineORMServiceProvider.php
+++ b/lib/Nutwerk/Provider/DoctrineORMServiceProvider.php
@@ -109,4 +109,9 @@ class DoctrineORMServiceProvider implements ServiceProviderInterface
             return $config;
         });
     }
+    
+    public function boot (Application $app) 
+    {
+        
+    }
 }


### PR DESCRIPTION
added the boot method to comply with ServiceProviderInterface. the lack of the boot method was causing an error in the latest version of silex.
