### PR TITLE
Create boot method

### DIFF
--- a/lib/Nutwerk/Provider/DoctrineORMServiceProvider.php
+++ b/lib/Nutwerk/Provider/DoctrineORMServiceProvider.php
@@ -109,4 +109,8 @@ class DoctrineORMServiceProvider implements ServiceProviderInterface
             return $config;
         });
     }
+
+    public function boot(Application $app) {
+        
+    }
 }


### PR DESCRIPTION
I've created an empty boot method just to comply with the Silex\ServiceProviderInterface. It works now with Siles v.1.0-DEV.
